### PR TITLE
Update style

### DIFF
--- a/src/post/PostSingleContent.scss
+++ b/src/post/PostSingleContent.scss
@@ -11,17 +11,21 @@
 
 .PostSingleContent__content,
 .PostSingleContent__replies .CommentBody {
-  font-size: 20px;
+  width: 820px;
+  font-size: 1em;
   line-height: 1.6em;
   overflow: hidden;
 
   img {
-    max-width: 100%;
     height: auto;
     margin: 2em 0;
     border: 1px solid rgba(0, 0, 0, 0.1);
-    display: block;
+    display: inline-block;
     background-color: white;
+    vertical-align: middle;
+    width: auto;
+    max-width: 100%;
+    max-height: none;
   }
 
   div.pull-right{


### PR DESCRIPTION
Will closes #230 
@adcpm some post created on steemit may break on busy.
like  https://steemit.com/health/@saramiller/how-to-yoga-a-chart-of-asanas
Images are placed with `&nbsp` exactly to fit well on steemit. This break on busy as container class limit max-width to 800px and steemit uses 50rem width which for me is ~840px. 