### PR TITLE
Separate messages by day groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,6 @@
     "lodash": "^4.0.0",
     "lodash-webpack-plugin": "^0.10.6",
     "matchmedia": "^0.1.2",
-    "moment": "^2.17.1",
     "morgan": "~1.6.1",
     "node-sass": "^3.10.0",
     "nodemon": "^1.9.2",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "lodash": "^4.0.0",
     "lodash-webpack-plugin": "^0.10.6",
     "matchmedia": "^0.1.2",
+    "moment": "^2.17.1",
     "morgan": "~1.6.1",
     "node-sass": "^3.10.0",
     "nodemon": "^1.9.2",

--- a/src/helpers/dateHelpers.js
+++ b/src/helpers/dateHelpers.js
@@ -1,0 +1,15 @@
+export function diffDays(date1, date2) {
+  return Math.abs(date1.getTime() - date2.getTime()) / (24 * 60 * 60 * 1000);
+}
+
+export function startOfDay(date) {
+  const year = date.getFullYear();
+  const month = date.getMonth();
+  const day = date.getDate();
+  // TODO
+  // To actually be on the start of *this* day, we need to be 1ms after its
+  // start, this is bug in the react-intl setup
+  const d = new Date(year, month, day);
+  d.setTime(d.getTime() + d.getTimezoneOffset() * 60 * 1000);
+  return d;
+}

--- a/src/messages/MessageDateGroup.js
+++ b/src/messages/MessageDateGroup.js
@@ -1,0 +1,82 @@
+import React, { Component } from 'react';
+import { FormattedDate, FormattedRelative } from 'react-intl';
+
+import './MessageList.scss';
+import MessageGroup from './MessageGroup';
+import { diffDays } from '../helpers/dateHelpers';
+import { propMessageDateGroup } from './messageGroupHelpers';
+
+export default class MessageDateGroup extends Component {
+  static propTypes = {
+    model: propMessageDateGroup.isRequired,
+  };
+
+  renderDay() {
+    if (diffDays(new Date(), this.props.model.day) < 2) {
+      return (
+        <FormattedRelative
+          value={this.props.model.day}
+          units="day"
+        />
+      );
+    }
+
+    return (
+      <FormattedDate
+        value={this.props.model.day}
+        year="numeric"
+        month="long"
+        day="numeric"
+      />
+    );
+  }
+
+  render() {
+    const day = this.renderDay();
+    return (
+      <div>
+        <div
+          style={{
+            position: 'relative',
+          }}
+        >
+          <h3
+            style={{
+              textAlign: 'center',
+            }}
+          >
+            <span
+              style={{
+                background: 'white',
+                borderRadius: 10,
+                padding: 10,
+                position: 'relative',
+                zIndex: 1,
+                textTransform: 'capitalize'
+              }}
+            >
+              {day}
+            </span>
+          </h3>
+
+          <hr
+            style={{
+              position: 'absolute',
+              top: '50%',
+              width: '100%',
+              margin: 0,
+              zIndex: 0,
+            }}
+          />
+        </div>
+
+        {this.props.model.messages.map((userGroup, i) => (
+          <MessageGroup
+            key={[userGroup.key, i]}
+            model={userGroup.messages}
+          />
+        ))}
+      </div>
+    );
+  }
+}

--- a/src/messages/MessageDateGroup.js
+++ b/src/messages/MessageDateGroup.js
@@ -40,12 +40,8 @@ export default class MessageDateGroup extends Component {
             position: 'relative',
           }}
         >
-          <h3
-            style={{
-              textAlign: 'center',
-            }}
-          >
-            <span
+          <p className="text-center">
+            <b
               style={{
                 background: 'white',
                 borderRadius: 10,
@@ -56,8 +52,8 @@ export default class MessageDateGroup extends Component {
               }}
             >
               {day}
-            </span>
-          </h3>
+            </b>
+          </p>
 
           <hr
             style={{

--- a/src/messages/MessageForm.js
+++ b/src/messages/MessageForm.js
@@ -19,7 +19,10 @@ export default class MessageForm extends Component {
   static propTypes = {
     placeholder: PropTypes.string,
     username: PropTypes.string,
-    channel: PropTypes.string,
+    channel: PropTypes.oneOf([
+      PropTypes.string,
+      PropTypes.array,
+    ]),
     onMessageSubmit: PropTypes.func
   };
 

--- a/src/messages/MessageForm.scss
+++ b/src/messages/MessageForm.scss
@@ -8,6 +8,7 @@
 
   $input-background: $messages-background;
 
+  z-index: 2;
   height: auto;
   position: fixed;
   bottom: 0;

--- a/src/messages/MessageGroup.js
+++ b/src/messages/MessageGroup.js
@@ -1,12 +1,12 @@
 import React from 'react';
-import { FormattedRelative, FormattedTime } from 'react-intl';
+import { FormattedTime } from 'react-intl';
 import { Link } from 'react-router';
 
 import Body from '../post/Body';
 import Avatar from '../widgets/Avatar';
 import ProfileTooltipOrigin from '../user/profileTooltip/ProfileTooltipOrigin';
 
-const Message = (props) => {
+const MessageGroup = (props) => {
   const { model } = props;
   const receivedAt = model[0].receivedAt;
   const senderUsername = (model[0].senderUsername || model[0].sentBy);
@@ -30,9 +30,9 @@ const Message = (props) => {
                   </Link>
                 </ProfileTooltipOrigin>
               </b>{' '}
+
               <span className="text-info">
-                <FormattedRelative value={receivedAt} />{' '}
-                (<FormattedTime value={receivedAt} />)
+                <FormattedTime value={receivedAt} />
               </span>
             </div>
             <Body body={model[0].text} />
@@ -58,4 +58,4 @@ const Message = (props) => {
   );
 };
 
-export default Message;
+export default MessageGroup;

--- a/src/messages/MessageList.js
+++ b/src/messages/MessageList.js
@@ -1,62 +1,11 @@
-/* eslint-disable react/no-find-dom-node */
 import React, { Component, PropTypes } from 'react';
-import ReactDOM from 'react-dom';
 import map from 'lodash/map';
-import reduce from 'lodash/reduce';
 import { connect } from 'react-redux';
-import debounce from 'lodash/debounce';
 
-import { sendReadAcknoledgement } from './messagesActions';
 import './MessageList.scss';
-import Message from './Message.js';
-
-function messageGroups(messages) {
-  // Group messages by username and minute
-  const ret = reduce(messages, (memo, message) => {
-    const key =
-      `${message.senderUsername}-${Math.floor(new Date(message.receivedAt).getTime() / 1000 / 60)}`;
-    if (!memo.latest) {
-      return {
-        all: memo.all,
-        latest: {
-          key,
-          messages: [message]
-        }
-      };
-    } else if (memo.latest.key === key) {
-      return {
-        all: memo.all,
-        latest: {
-          key,
-          messages: memo.latest.messages.concat([message]),
-        },
-      };
-    }
-
-    return {
-      all: memo.all.concat([memo.latest]),
-      latest: {
-        key,
-        messages: [message],
-      }
-    };
-  }, {
-    latest: null,
-    all: [],
-  });
-
-  return ret.all.concat(ret.latest ? [ret.latest] : []);
-}
-
-const sortBasedOnDate = list =>
-  list.sort((itemA, itemB) => {
-    if (itemA.messages && itemB.messages) {
-      const itemADate = new Date(itemA.messages[0].receivedAt).getTime();
-      const itemBDate = new Date(itemB.messages[0].receivedAt).getTime();
-      return itemADate > itemBDate ? 1 : -1;
-    }
-    return -1;
-  });
+import MessageDateGroup from './MessageDateGroup';
+import { groupMessagesByDate } from './messageGroupHelpers';
+import { sendReadAcknoledgement } from './messagesActions';
 
 class MessageList extends Component {
   static propTypes = {
@@ -81,11 +30,11 @@ class MessageList extends Component {
 
   render() {
     const { messages, username } = this.props;
-    const groups = sortBasedOnDate(messageGroups(messages));
-    const messageEls = map(groups, ({ messages: messageGroup, key }, i) => (
-      <Message
-        key={[key, i]}
-        model={messageGroup}
+    const dateGroups = groupMessagesByDate(messages);
+    const messageEls = map(dateGroups, (dateGroup, i) => (
+      <MessageDateGroup
+        key={i}
+        model={dateGroup}
       />
     ));
 

--- a/src/messages/messageGroupHelpers.js
+++ b/src/messages/messageGroupHelpers.js
@@ -1,0 +1,106 @@
+import groupBy from 'lodash/groupBy';
+import map from 'lodash/map';
+import reduce from 'lodash/reduce';
+import sortBy from 'lodash/sortBy';
+import { PropTypes } from 'react';
+
+import { startOfDay } from '../helpers/dateHelpers';
+
+/**
+ * Group messages by username and minute
+ */
+
+function groupMessagesByUser(messages) {
+  const smessages = sortBy(messages, 'receivedAt');
+  const ret = reduce(smessages, (memo, message) => {
+    const receivedAtDate = new Date(message.receivedAt);
+    const day = startOfDay(receivedAtDate).getTime();
+    const key =
+      `${message.senderUsername}-${Math.floor(receivedAtDate.getTime() / 1000 / 60)}`;
+    if (!memo.latest) {
+      return {
+        all: memo.all,
+        latest: {
+          day,
+          key,
+          messages: [message]
+        }
+      };
+    } else if (memo.latest.key === key) {
+      return {
+        all: memo.all,
+        latest: {
+          key,
+          day,
+          messages: memo.latest.messages.concat([message]),
+        },
+      };
+    }
+
+    return {
+      all: memo.all.concat([memo.latest]),
+      latest: {
+        key,
+        day,
+        messages: [message],
+      }
+    };
+  }, {
+    latest: null,
+    all: [],
+  });
+
+  return ret.all.concat(ret.latest ? [ret.latest] : []);
+}
+
+/**
+ * Groups messages by date and username and minute. Output is sorted.
+ *
+ * @param {Array} messages
+ * @returns {Array} dateMessageGroups
+ * @returns {Object} dateMessageGroups[i] A day of messages
+ * @returns {Date} dateMessageGroups[i].date The day of this group
+ * @returns {Array} dateMessageGroups[i].messages The username/minute groups in this day
+ * @returns {Object} dateMessageGroups[i].messages[i].messages The messages in
+ *   this username/minute group
+ *
+ * @example
+ *   messageGroups(someMessages);
+ *   // =>
+ *   // [
+ *   //   {
+ *   //     day: Fri Jan 13 2017 00:00:00 GMT-0200 (BRST),
+ *   //     messages: [
+ *   //       {
+ *   //         key: 'yamadapc-1484272800000',     // <- `${username}-${minute}`
+ *   //         messages: [...]                    // <- messages sent in this minute by this user
+ *   //       },
+ *   //       ...
+ *   //     ],
+ *   //   },
+ *   //   ...
+ *   // ]
+ */
+
+export function groupMessagesByDate(messages) {
+  const umessages = groupMessagesByUser(messages);
+  const dayGroups = map(groupBy(umessages, (m) => m.day), (userMessages, day) => ({
+    messages: userMessages,
+    day: new Date(+day),
+  }));
+
+  return sortBy(
+    dayGroups,
+    (v) => v.day
+  );
+}
+
+export const propMessageGroup = PropTypes.shape({
+  key: PropTypes.string.isRequired,
+  messages: PropTypes.array,
+});
+
+export const propMessageDateGroup = PropTypes.shape({
+  day: PropTypes.instanceOf(Date).isRequired,
+  messages: PropTypes.arrayOf(propMessageGroup),
+});


### PR DESCRIPTION
- Uses `react-intl` and a new `dateHelpers` module to separate messages by
  date group
- Renames messages components so they make more sense
- Documents the grouping functions
- Simplifies message sorting
- Offsets `startOfDay`s so `react-intl` doesn't need to handle timezones
  propertly (which it isn't)