### PR TITLE
Move post title on top of the page

### DIFF
--- a/src/post/PostSingleContent.js
+++ b/src/post/PostSingleContent.js
@@ -44,6 +44,7 @@ const PostSingleContent = ({
   return (
     <div className="PostSingleContent my-4">
       <div className="container">
+        <h1>{content.title}</h1>
         <div className="PostSingleContent__header mb-3">
           <Link to={`/@${content.author}`}>
             <Avatar sm username={content.author} />
@@ -63,14 +64,10 @@ const PostSingleContent = ({
           </span>
         </div>
         <div className="PostSingleContent__content mb-3">
-          <h1 className="mvl">{content.title}</h1>
-
-          { hasAnchoredLink ?
-            <BodyShort body={content.body} />
-            :
-            <Body body={content.body} jsonMetadata={content.json_metadata} />
+          {hasAnchoredLink
+            ? <BodyShort body={content.body} />
+            : <Body body={content.body} jsonMetadata={content.json_metadata} />
           }
-
         </div>
         {jsonMetadata.tags &&
           <div className="mb-3">

--- a/src/styles/modules/headings.scss
+++ b/src/styles/modules/headings.scss
@@ -11,7 +11,7 @@ h1, h2, h3 {
 }
 
 h1 {
-  font-size: 2.2rem;
+  font-size: 2rem;
   letter-spacing: 0;
   margin-bottom: 0.8em;
 }
@@ -39,7 +39,7 @@ p {
 
 @media all and (max-width: 768px) {
   h1 {
-    font-size: 2rem;
+    font-size: 1.8rem;
   }
 
   h2, h3 {


### PR DESCRIPTION
Actually when you see an article you will see the author en details first then the post title. It seem more common to show first the title before post information. This is a small PR for change it.