### PR TITLE
Fix issue with Youtube thumbs

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "draft-js-import-markdown": "github:nil1511/draft-js-import-markdown#build",
     "draft-js-markdown-shortcuts-plugin": "github:nil1511/draft-js-markdown-shortcuts-plugin#build",
     "draft-js-plugins": "github:nil1511/draft-js-plugins#build",
-    "embedjs": "0.0.3",
+    "embedjs": "^0.0.4",
     "emojione": "^2.2.7",
     "emojione-picker": "^1.1.0",
     "express": "~4.13.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2144,9 +2144,9 @@ elliptic@^6.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.0"
 
-embedjs@0.0.3:
-  version "0.0.3"
-  resolved "https://registry.yarnpkg.com/embedjs/-/embedjs-0.0.3.tgz#e01ffd7fee312b202941d0aa505d5b34a7471cc8"
+embedjs@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/embedjs/-/embedjs-0.0.4.tgz#b92242069fe246333c5d3869a14e7ef930d48642"
   dependencies:
     url-extractor "^2.0.2"
 


### PR DESCRIPTION
Some Youtube thumb was not working on Busy, i've changed the thumb link to a better one on Embed.js and updated to v0.0.4